### PR TITLE
Add file extension check when specifying a queue in headless mode - Fixes Issue #26

### DIFF
--- a/src/core/test_queue.cpp
+++ b/src/core/test_queue.cpp
@@ -71,7 +71,14 @@ bool TestQueue::save(const std::string& filename) {
 }
 
 bool TestQueue::load(const std::string& filename) {
-  std::ifstream file(filename + ".json");
+  std::string full_filename = filename;
+
+  // Check if the filename already ends with ".json"
+  if (filename.size() < 5 || filename.substr(filename.size() - 5) != ".json") {
+    full_filename += ".json";
+  }
+
+  std::ifstream file(full_filename);
   if (file.is_open()) {
     nlohmann::json j;
     file >> j;
@@ -82,6 +89,7 @@ bool TestQueue::load(const std::string& filename) {
   }
   return false;
 }
+
 void TestQueue::addPermutedTests(
     const TestConfig& base, const std::vector<std::vector<float>>& permutations,
     const std::vector<std::string>& parameter_names) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a file extension check in `TestQueue::load` that checks whether when the user calls headless mode using the `-q` extension, if they have included the file extension in the queue name.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes bug related to issue #26 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the following commands in Debug and Release mode, and ensuring they worked:
```
./testbed --headless -v -q example_queue
./testbed --headless -v -q example_queue.json
```